### PR TITLE
Closing an already closed OutputStream should have no effect.

### DIFF
--- a/src/main/java/net/iharder/Base64.java
+++ b/src/main/java/net/iharder/Base64.java
@@ -2020,6 +2020,11 @@ public class Base64
          */
         @Override
         public void close() throws java.io.IOException {
+            // 0.  If the stream is already closed then invoking this method has no effect.
+            if (out == null) {
+                return;
+            }
+
             // 1. Ensure that pending characters are written
             flushBase64();
 

--- a/src/test/java/net/iharder/Base64Test.java
+++ b/src/test/java/net/iharder/Base64Test.java
@@ -1,5 +1,6 @@
 package net.iharder;
 
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
@@ -25,7 +26,9 @@ public class Base64Test extends TestCase
         byte[] data = createData(length);
         ByteArrayOutputStream out_bytes = new ByteArrayOutputStream();
         OutputStream out = new Base64.OutputStream(out_bytes);
-        out.write(data);
+        BufferedOutputStream bos = new BufferedOutputStream(out);
+        bos.write(data);
+        bos.close();
         out.close();
         byte[] encoded = out_bytes.toByteArray();
         byte[] decoded = Base64.decode(encoded, 0, encoded.length, 


### PR DESCRIPTION
Before, it threw a NullPointerException. This will allow using try-with-resources when f.e. combining a GZIPOutputStream and a Base64.OutputStream.